### PR TITLE
group Hackage updates

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,1 +1,8 @@
-{}
+{
+    "packageRules": [
+        {
+            "matchDatasources": ["hackage"],
+            "groupName": "Hackage deps"
+        }
+    ]
+}


### PR DESCRIPTION
I can't upgrade my crypton dep to allow 1.1 because jose < 1.13 doesn't support it, but I can't upgrade jose to 1.13 because that needs crypton-1.1. That is, I can't prove that this configuration works unless I allow both at once.